### PR TITLE
Fix inconsistent side counts in menu

### DIFF
--- a/Scripts/level/whirly_madness/whirly_madness.lua
+++ b/Scripts/level/whirly_madness/whirly_madness.lua
@@ -16,6 +16,7 @@ function onInit()
 	l_setShowPlayerTrail(false)
 	l_setDarkenUnevenBackgroundChunk(false)
 	l_setRotationSpeed(0.5)
+	l_setSides(6)
 end
 
 progress = 0


### PR DESCRIPTION
The preview in the menu has the same side count as the last level, this is fixed by setting sides in onInit (onLoad would work too)